### PR TITLE
Architecture detection for IPFS installation in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM node:15.8.0-buster
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-RUN wget -q https://dist.ipfs.io/go-ipfs/v0.8.0/go-ipfs_v0.8.0_linux-amd64.tar.gz && \
-    tar -xvzf go-ipfs_v0.8.0_linux-amd64.tar.gz && \
-    cd go-ipfs && \
-    bash install.sh
+COPY ./installIpfs.sh .
+RUN bash installIpfs.sh
 
 WORKDIR /multisetups
 COPY . /multisetups/

--- a/installIpfs.sh
+++ b/installIpfs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+arch=$(uname -m)
+
+if [[ "$arch" =~ "^arm" ]]; then
+    url=https://dist.ipfs.io/go-ipfs/v0.8.0/go-ipfs_v0.8.0_linux-arm64.tar.gz
+else
+    url=https://dist.ipfs.io/go-ipfs/v0.8.0/go-ipfs_v0.8.0_linux-amd64.tar.gz
+fi
+
+echo "Downloading $url"
+wget -q -O ipfs.tar.gz $url 
+tar -xvzf ipfs.tar.gz
+cd go-ipfs
+bash install.sh


### PR DESCRIPTION
Checks if the architecture is ARM. If so, downloads the ARM IPFS binary. Otherwise, uses amd64. 

https://github.com/appliedzkp/multisetups/issues/7