### PR TITLE
allow volume source to be set by $MULTISETUPS_ZKEYS_DIR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - type: bind
         target: /ceremony
-        source: ./
+        source: ${CEREMONY_DIR:-./ceremony}
 
 volumes:
   ceremony:


### PR DESCRIPTION
It can be useful to allow the ceremony volume to be bind-mounted from elsewhere, e.g. outside the multisetups repo.