### PR TITLE
Use "public" interface to snarkjs CLI

### DIFF
--- a/ts/contribute.ts
+++ b/ts/contribute.ts
@@ -113,7 +113,7 @@ const contribute = async (
 
         const o = path.join(dirname, c.original)
         const n = path.join(newDirname, c['new'])
-        const cmd = `node ./node_modules/snarkjs/build/cli.cjs zkey contribute ${o} ${n}`
+        const cmd = `node ./node_modules/.bin/snarkjs zkey contribute ${o} ${n}`
         let out = shelljs.exec(`echo ${currentEntropy} | ${cmd}`, { silent: true })
         out = out.replace(/Enter a random text\. \(Entropy\): /, '$&\n')
         transcript += `${cmd}\n`

--- a/ts/verify.ts
+++ b/ts/verify.ts
@@ -67,7 +67,7 @@ const verify = async (
 
     console.log('You should run the following commands to verify the contribution:')
     for (const c of contribs) {
-        const cmd = `node ./node_modules/snarkjs/build/cli.cjs zkey verify <R1CS_FILE> ${ptauFile} ${c}`
+        const cmd = `node ./node_modules/.bin/snarkjs zkey verify <R1CS_FILE> ${ptauFile} ${c}`
         console.log(cmd)
     }
 


### PR DESCRIPTION
It's safer to use the script which snarkjs provides as its CLI, rather than assuming anything about the internals of snarkjs (e.g.  that there is a build artifact called `cli.cjs`).

It's also more concise and readable.